### PR TITLE
Make RUST_LOG impact --journald

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +248,30 @@ checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "sd-notify"
@@ -378,9 +411,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
 dependencies = [
  "ansi_term",
+ "matchers",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ inotify = { version = "0.10.0", default-features = false }
 nix = "0.25.0"
 once_cell = "1.14.0"
 tracing = "0.1.35"
-tracing-subscriber = "0.3.6"
+tracing-subscriber = { version = "0.3.6", features = ["env-filter"] }
 
 [dependencies.tracing-journald]
 version = "0.3"


### PR DESCRIPTION
I verified it locally. Default to `info` if nothing is set.

With `RUST_LOG=trace`
```
Sep 21 15:19:45 aya tailsrv[329073]: Bound socket
Sep 21 15:19:45 aya tailsrv[329073]: Handling client connections
Sep 21 15:19:45 aya tailsrv[329073]: Opened file
Sep 21 15:19:45 aya tailsrv[329073]: Initial file size: 0kB
Sep 21 15:19:45 aya tailsrv[329073]: Created an inotify watch
Sep 21 15:20:03 aya tailsrv[329073]: New file size: 32
Sep 21 15:20:04 aya tailsrv[329073]: New file size: 36
```

With `RUST_LOG=debug`
```
Sep 21 15:20:08 aya tailsrv[329088]: Bound socket
Sep 21 15:20:08 aya tailsrv[329088]: Handling client connections
Sep 21 15:20:08 aya tailsrv[329088]: Opened file
Sep 21 15:20:08 aya tailsrv[329088]: Initial file size: 0kB
Sep 21 15:20:08 aya tailsrv[329088]: Created an inotify watch
```

Fixes #3